### PR TITLE
Cbrew occupancymap

### DIFF
--- a/include/geometric_shapes/shapes.h
+++ b/include/geometric_shapes/shapes.h
@@ -318,6 +318,9 @@ public:
   virtual bool isFixed() const;
 
   virtual boost::shared_ptr<occmap_iterator> begin() = 0;
+  virtual boost::shared_ptr<occmap_iterator> end() = 0;
+  virtual boost::shared_ptr<occmap_iterator> begin_bbx(const Eigen::Vector3d &min, const Eigen::Vector3d &max) = 0;
+  virtual boost::shared_ptr<occmap_iterator> end_bbx() = 0;
 };
 
 /** \brief Shared pointer to a OcTree */
@@ -406,6 +409,17 @@ public:
 
   virtual boost::shared_ptr<occmap_iterator> begin() {
     return boost::shared_ptr<occmap_iterator>(new occmap_iterator_octomap<octomap::OcTree::leaf_iterator>(octree->begin_leafs(), octree));
+  }
+  virtual boost::shared_ptr<occmap_iterator> end() {
+    return boost::shared_ptr<occmap_iterator>(new occmap_iterator_octomap<octomap::OcTree::leaf_iterator>(octree->end_leafs(), octree));
+  }
+  virtual boost::shared_ptr<occmap_iterator> begin_bbx(const Eigen::Vector3d &min, const Eigen::Vector3d &max) {
+    octomap::point3d omin = octomap::point3d(min(0),min(1),min(2));
+    octomap::point3d omax = octomap::point3d(max(0),max(1),max(2));
+    return boost::shared_ptr<occmap_iterator>(new occmap_iterator_octomap<octomap::OcTree::leaf_bbx_iterator>(octree->begin_leafs_bbx(omin, omax), octree));
+  }
+  virtual boost::shared_ptr<occmap_iterator> end_bbx() {
+    return boost::shared_ptr<occmap_iterator>(new occmap_iterator_octomap<octomap::OcTree::leaf_bbx_iterator>(octree->end_leafs_bbx(), octree));
   }
 
   OctTreePtr octree;

--- a/src/shape_operations.cpp
+++ b/src/shape_operations.cpp
@@ -606,6 +606,8 @@ const std::string& shapeStringName(const Shape *shape)
       return Mesh::STRING_NAME;
     case OCTREE:
       return OcTree::STRING_NAME;
+    case OCCMAP:
+      return OccMap::STRING_NAME;
     default:
       return unknown;
     }

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -46,6 +46,7 @@ const std::string shapes::Cone::STRING_NAME = "cone";
 const std::string shapes::Mesh::STRING_NAME = "mesh";
 const std::string shapes::Plane::STRING_NAME = "plane";
 const std::string shapes::OcTree::STRING_NAME = "octree";
+const std::string shapes::OccMap::STRING_NAME = "occmap";
 
 shapes::Shape::Shape()
 {
@@ -164,6 +165,11 @@ shapes::OcTree::OcTree(const boost::shared_ptr<const octomap::OcTree> &t) : octr
   type = OCTREE;
 }
 
+shapes::OccMap::OccMap() : Shape()
+{
+  type = OCCMAP;
+}
+
 shapes::Shape* shapes::Sphere::clone() const
 {
   return new Sphere(radius);
@@ -225,6 +231,11 @@ shapes::Shape* shapes::OcTree::clone() const
 void shapes::OcTree::scaleAndPadd(double scale, double padd)
 {
   logWarn("OcTrees cannot be scaled or padded");
+}
+
+void shapes::OccMap::scaleAndPadd(double scale, double padd)
+{
+  logWarn("OccMaps cannot be scaled or padded");
 }
 
 void shapes::Plane::scaleAndPadd(double scale, double padding)
@@ -369,6 +380,11 @@ bool shapes::Shape::isFixed() const
 }
 
 bool shapes::OcTree::isFixed() const
+{
+  return true;
+}
+
+bool shapes::OccMap::isFixed() const
 {
   return true;
 }


### PR DESCRIPTION
This is an initial implementation of an abstract occupancy map that can be used instead of direct octomaps for occupancy mapping in packages such as moveit.  The initial API only provides an iterator as most consumers of the Octomap API only use the octomap iterators.  The abstract API to populate and update the map still needs to be worked out.
